### PR TITLE
chore: update tx3up install URLs after up→tx3up rename

### DIFF
--- a/integrations/install-tx3-nextjs/README.md
+++ b/integrations/install-tx3-nextjs/README.md
@@ -125,7 +125,7 @@ The installer can optionally install the trix (TX3 package manager) via tx3up:
 
 **Manual installation commands:**
 ```bash
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/tx3-lang/up/releases/latest/download/tx3up-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/tx3-lang/tx3up/releases/latest/download/tx3up-installer.sh | sh
 tx3up
 ```
 

--- a/integrations/install-tx3-nextjs/src/commands/init.ts
+++ b/integrations/install-tx3-nextjs/src/commands/init.ts
@@ -104,7 +104,7 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
         spinner.succeed('🔧 trix installed successfully');
       } catch (error) {
         spinner.warn('⚠️ trix installation failed, but continuing with project setup');
-        console.log(chalk.yellow(`You can install trix manually later with: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/tx3-lang/up/releases/latest/download/tx3up-installer.sh | sh && tx3up`));
+        console.log(chalk.yellow(`You can install trix manually later with: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/tx3-lang/tx3up/releases/latest/download/tx3up-installer.sh | sh && tx3up`));
       }
     }
 

--- a/integrations/install-tx3-nextjs/src/commands/install.ts
+++ b/integrations/install-tx3-nextjs/src/commands/install.ts
@@ -139,7 +139,7 @@ export async function installCommand(options: InstallOptions = {}): Promise<void
         } else {
           console.log(chalk.yellow('⚠️ trix installation failed, but continuing with TX3 setup'));
         }
-        console.log(chalk.yellow(`You can install trix manually later with: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/tx3-lang/up/releases/latest/download/tx3up-installer.sh | sh && tx3up`));
+        console.log(chalk.yellow(`You can install trix manually later with: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/tx3-lang/tx3up/releases/latest/download/tx3up-installer.sh | sh && tx3up`));
       }
     }
 

--- a/integrations/install-tx3-nextjs/src/utils/trix-installer.ts
+++ b/integrations/install-tx3-nextjs/src/utils/trix-installer.ts
@@ -9,7 +9,7 @@ export class TrixInstaller {
         console.log(chalk.blue('📥 Installing tx3up...'));
       }
       
-      const tx3upCommand = `curl --proto '=https' --tlsv1.2 -LsSf https://github.com/tx3-lang/up/releases/latest/download/tx3up-installer.sh | sh`;
+      const tx3upCommand = `curl --proto '=https' --tlsv1.2 -LsSf https://github.com/tx3-lang/tx3up/releases/latest/download/tx3up-installer.sh | sh`;
       
       execSync(tx3upCommand, { 
         stdio: verbose ? 'inherit' : 'pipe'

--- a/integrations/next-tx3/README.md
+++ b/integrations/next-tx3/README.md
@@ -27,7 +27,7 @@ Make sure you have the `trix` compiler installed:
 
 ```bash
 # Install tx3up installer
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/tx3-lang/up/releases/latest/download/tx3up-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/tx3-lang/tx3up/releases/latest/download/tx3up-installer.sh | sh
 
 # Install trix
 tx3up
@@ -176,7 +176,7 @@ The plugin automatically:
 **Solution:** Install the trix tool:
 ```bash
 # Install tx3up installer
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/tx3-lang/up/releases/latest/download/tx3up-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/tx3-lang/tx3up/releases/latest/download/tx3up-installer.sh | sh
 
 # Install trix
 tx3up

--- a/integrations/next-tx3/src/utils/trix-installer.ts
+++ b/integrations/next-tx3/src/utils/trix-installer.ts
@@ -39,7 +39,7 @@ export function displayTrixInstallationInstructions(): void {
   console.log(chalk.red('❌ Trix compiler not found!'));
   console.log(chalk.yellow('\n📦 To install trix, run these commands:'));
   console.log(chalk.cyan('\n# Install tx3up installer'));
-  console.log(chalk.white('curl --proto \'=https\' --tlsv1.2 -LsSf https://github.com/tx3-lang/up/releases/latest/download/tx3up-installer.sh | sh'));
+  console.log(chalk.white('curl --proto \'=https\' --tlsv1.2 -LsSf https://github.com/tx3-lang/tx3up/releases/latest/download/tx3up-installer.sh | sh'));
   console.log(chalk.cyan('\n# Install trix'));
   console.log(chalk.white('tx3up'));
   console.log(chalk.yellow('\n💡 After installation, restart your development server.'));

--- a/integrations/rollup-plugin-tx3/src/index.ts
+++ b/integrations/rollup-plugin-tx3/src/index.ts
@@ -24,7 +24,7 @@ export function isTrixAvailable(options: SanitizedOptions) {
     console.log(chalk.red('❌ Trix compiler not found!'));
     console.log(chalk.yellow('\n📦 To install trix, run these commands:'));
     console.log(chalk.cyan('\n# Install tx3up installer'));
-    console.log(chalk.white('curl --proto \'=https\' --tlsv1.2 -LsSf https://github.com/tx3-lang/up/releases/latest/download/tx3up-installer.sh | sh'));
+    console.log(chalk.white('curl --proto \'=https\' --tlsv1.2 -LsSf https://github.com/tx3-lang/tx3up/releases/latest/download/tx3up-installer.sh | sh'));
     console.log(chalk.cyan('\n# Install trix'));
     console.log(chalk.white('tx3up'));
     console.log(chalk.yellow('\n💡 After installation, restart your development server.'));


### PR DESCRIPTION
The `tx3-lang/up` repository was renamed to `tx3-lang/tx3up`. This updates the `tx3up` install URLs printed/used by the Next.js and Rollup integration helpers and their READMEs.

GitHub redirects keep the old URL working, so this is a correctness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)