### PR TITLE
feat(facade): unified Tx3ClientBuilder for §3.3/§3.6 parity

### DIFF
--- a/.trix/client-lib/protocol.ts.hbs
+++ b/.trix/client-lib/protocol.ts.hbs
@@ -2,13 +2,13 @@
 // Target TII version: {{tii.tii.version}}
 
 import {
-    TrpClient,
-    type ClientOptions,
-    type SubmitParams,
-    type SubmitResponse,
-    type TxEnvelope,
-} from "tx3-sdk/trp";
-import type { ArgValue } from "tx3-sdk";
+    Party,
+    type Profile as SdkProfile,
+    Tx3Client,
+    Tx3ClientBuilder,
+    type TxBuilder,
+} from "tx3-sdk";
+import type { ClientOptions } from "tx3-sdk/trp";
 
 /** Protocol identity, embedded from the TII at codegen time. */
 export const PROTOCOL_NAME = "{{tii.protocol.name}}";
@@ -21,14 +21,6 @@ export const TARGET_TII_VERSION = "{{tii.tii.version}}";
 export const ENVIRONMENT_SCHEMA = {{{json tii.environment}}} as const;
 
 {{/if}}
-/**
- * Profiles embedded from the TII, keyed by name. Each entry carries that
- * profile's `environment` values and `parties` addresses.
- */
-export const PROFILES = {{{json tii.profiles}}} as const;
-
-export type ProfileName = keyof typeof PROFILES;
-
 type TirEnvelope = {
     content: string;
     encoding: "hex" | "base64";
@@ -36,12 +28,7 @@ type TirEnvelope = {
 };
 
 {{#each tii.transactions}}
-export type {{pascalCase @key}}Params = {
-{{#each params.properties}}
-    {{camelCase @key}}: ArgValue | {{schemaTypeFor this "typescript"}};
-{{/each}}
-};
-
+/** Embedded TIR envelope for the `{{@key}}` transaction. */
 export const {{constantCase @key}}_TIR = {
     content: "{{tir.content}}",
     encoding: "{{tir.encoding}}",
@@ -49,40 +36,75 @@ export const {{constantCase @key}}_TIR = {
 } as const satisfies TirEnvelope;
 
 {{/each}}
-/** Thin protocol facade over the TRP client. */
-export class Client {
-    readonly #trp: TrpClient;
-    readonly #environment?: Record<string, unknown>;
-    readonly #parties: Record<string, string>;
-
-    constructor(options: ClientOptions, profile?: ProfileName) {
-        this.#trp = new TrpClient(options);
-        if (profile !== undefined) {
-            const selected = PROFILES[profile];
-            this.#environment = selected.environment as Record<string, unknown>;
-            this.#parties = selected.parties as Record<string, string>;
-        } else {
-            this.#parties = {};
-        }
-    }
-
-    async #resolve(tir: TirEnvelope, args: Record<string, unknown>): Promise<TxEnvelope> {
-        return await this.#trp.resolve({
-            tir,
-            args: { ...this.#parties, ...args },
-            ...(this.#environment !== undefined ? { env: this.#environment } : {}),
-        });
-    }
 {{#each tii.transactions}}
+export type {{pascalCase @key}}Params = {
+{{#each params.properties}}
+    {{camelCase @key}}: {{schemaTypeFor this "typescript"}};
+{{/each}}
+};
 
-    /** Resolves the {{@key}} transaction. */
-    async {{camelCase @key}}(args: {{pascalCase @key}}Params): Promise<TxEnvelope> {
-        return await this.#resolve({{constantCase @key}}_TIR, args);
-    }
+{{/each}}
+{{#if tii.profiles}}
+{{#each tii.profiles}}
+const {{constantCase @key}}_PROFILE: SdkProfile = {
+    environment: {{{json this.environment}}} as Record<string, unknown>,
+    parties: {{{json this.parties}}} as Record<string, string>,
+};
 {{/each}}
 
-    /** Submits a signed transaction to the network. */
-    async submit(params: SubmitParams): Promise<SubmitResponse> {
-        return await this.#trp.submit(params);
+/** Profiles declared by the protocol. Required argument to `Client`. */
+export type Profile = {{#each tii.profiles}}"{{@key}}"{{#unless @last}} | {{/unless}}{{/each}};
+
+{{/if}}
+/**
+ * Typed protocol client exposing the full transaction lifecycle.
+ *
+ * Wraps the runtime SDK's `Tx3Client` — all lifecycle state, party storage,
+ * resolve/sign/submit/wait, and error handling live in the SDK. This wrapper
+ * only adds the typed shape of per-transaction methods, per-party setters,
+ * and the embedded protocol fragments.
+ */
+export class Client {
+    #inner: Tx3Client;
+
+    constructor(options: ClientOptions{{#if tii.profiles}}, profile: Profile{{/if}}) {
+        const transactions = new Map<string, TirEnvelope>();
+{{#each tii.transactions}}
+        transactions.set("{{@key}}", {{constantCase @key}}_TIR);
+{{/each}}
+
+{{#if tii.profiles}}
+        const profiles = new Map<string, SdkProfile>();
+{{#each tii.profiles}}
+        profiles.set("{{@key}}", {{constantCase @key}}_PROFILE);
+{{/each}}
+{{else}}
+        const profiles = new Map<string, SdkProfile>();
+{{/if}}
+
+        this.#inner = Tx3ClientBuilder.fromParts(transactions, profiles, [])
+            .trp(options){{#if tii.profiles}}
+            .withProfile(profile){{/if}}
+            .build();
     }
+
+{{#each tii.parties}}
+    /**
+     * Binds the `{{@key}}` party (signer or read-only address). Overrides any
+     * address declared for that party by the selected profile.
+     */
+    with{{pascalCase @key}}(party: Party): this {
+        this.#inner = this.#inner.withPartyUnchecked("{{@key}}", party);
+        return this;
+    }
+
+{{/each}}
+{{#each tii.transactions}}
+    /** Builds the `{{@key}}` transaction. Drive the returned builder with
+     *  `.resolve()` and the rest of the lifecycle chain. */
+    {{camelCase @key}}(args: {{pascalCase @key}}Params): TxBuilder {
+        return this.#inner.tx("{{@key}}").args(args as Record<string, unknown>);
+    }
+
+{{/each}}
 }

--- a/README.md
+++ b/README.md
@@ -22,9 +22,7 @@ npm install tx3-sdk
 
 ```ts
 import {
-  Tx3Client,
   Protocol,
-  TrpClient,
   Party,
   Ed25519Signer,
   PollConfig,
@@ -33,18 +31,18 @@ import {
 // 1. Load a compiled .tii protocol
 const protocol = await Protocol.fromFile("./transfer.tii");
 
-// 2. Connect to a TRP server
-const trp = new TrpClient({ endpoint: "http://localhost:3000/rpc" });
-
-// 3. Configure signer and parties
+// 2. Build a client: configure TRP, profile, and parties on the builder
 const signer = Ed25519Signer.fromHex("addr_test1...", "deadbeef...");
 
-const tx3 = new Tx3Client(protocol, trp)
+const tx3 = protocol
+  .client()
+  .trpEndpoint("http://localhost:3000/rpc")
   .withProfile("preprod")
   .withParty("sender", Party.signer(signer))
-  .withParty("receiver", Party.address("addr_test1..."));
+  .withParty("receiver", Party.address("addr_test1..."))
+  .build();
 
-// 4. Build, resolve, sign, submit, and wait for confirmation
+// 3. Build, resolve, sign, submit, and wait for confirmation
 const status = await tx3
   .tx("transfer")
   .arg("quantity", 10_000_000n)
@@ -56,14 +54,24 @@ const status = await tx3
 console.log(status.stage); // "confirmed"
 ```
 
+All fallible validation — TRP endpoint present, profile declared, every bound
+party declared — happens inside `build()`, which throws `MissingTrpEndpointError`,
+`UnknownProfileError`, or `UnknownPartyError` (all rooted at `Tx3Error`, discriminable
+via `instanceof`). Optional setters never throw, so chains stay fluent. Profile
+selection is **builder-only**: there is no profile-switching method on the built
+client. Switching profiles requires a new builder.
+
 ## Concepts
 
 | SDK Type | Glossary Term | Description |
 |---|---|---|
-| `Protocol` | TII / Protocol | Loaded `.tii` exposing transactions, parties, profiles |
-| `Tx3Client` | Facade | Entry point holding protocol, TRP client, and party bindings |
-| `TxBuilder` | Invocation builder | Collects args, resolves via TRP |
+| `Protocol` | TII / Protocol | Loaded `.tii` exposing transactions, parties, profiles. `protocol.client()` returns a fresh `Tx3ClientBuilder` |
+| `Tx3ClientBuilder` | Client builder | Fluent builder seeded by `Protocol.client()` or `Tx3ClientBuilder.fromParts(...)`; absorbs all fallible validation in `build()` |
+| `Tx3Client` | Facade | Output of `Tx3ClientBuilder.build()` — owns deconstructed protocol parts, TRP client, profile, and party bindings |
+| `TxBuilder` | Invocation builder | Source-agnostic; collects args, resolves via TRP |
 | `Party` | Party | `Party.address(...)` (read-only) or `Party.signer(...)` (signing) |
+| `Profile` | Profile | `{ environment, parties }` value baked into the client; embedded by codegen plugins, decomposed from `Protocol` by `fromProtocol` |
+| `MissingTrpEndpointError` / `UnknownPartyError` | Builder errors | Thrown by `build()`; subclass of `BuilderError`, rooted at `Tx3Error` |
 | `Signer` | Signer | Interface producing a `TxWitness` for a `SignRequest` |
 | `SignRequest` | SignRequest | Input passed to `Signer.sign`: `txHashHex` + `txCborHex` |
 | `CardanoSigner` | Cardano Signer | BIP32-Ed25519 signer at `m/1852'/1815'/0'/0/0` |
@@ -92,6 +100,25 @@ import { CardanoSigner, Cip30Signer, cip30Party } from "tx3-sdk/signer";
 
 ```ts
 const protocol = Protocol.fromString(await (await fetch("/transfer.tii")).text());
+```
+
+### Skipping the runtime `.tii` (codegen flow)
+
+If you've run `trix codegen` to generate typed bindings, your generated `Client`
+embeds the per-transaction TIR envelopes and per-profile data at codegen time —
+no `.tii` artifact at runtime. Under the hood it seeds the same builder via
+`Tx3ClientBuilder.fromParts(transactions, profiles, knownParties)` and routes
+typed per-party setters through `withPartyUnchecked`. You can also call
+`fromParts` directly from hand-written code:
+
+```ts
+import { Tx3ClientBuilder, Party } from "tx3-sdk";
+
+const tx3 = Tx3ClientBuilder
+  .fromParts(transactions, profiles, ["sender", "receiver"])
+  .trpEndpoint("http://localhost:3000/rpc")
+  .withPartyUnchecked("sender", Party.signer(signer))
+  .build();
 ```
 
 ### Low-level TRP client
@@ -141,15 +168,18 @@ class MySigner implements Signer {
 wallet (Eternl, Lace, Nami, …) directly into the standard chain:
 
 ```ts
-import { Tx3Client, Party } from "tx3-sdk";
+import { Protocol, Party } from "tx3-sdk";
 import { cip30Party } from "tx3-sdk/signer";
 
 const api = await window.cardano.eternl.enable();
 
-const tx3 = new Tx3Client(protocol, trp)
+const tx3 = protocol
+  .client()
+  .trpEndpoint("http://localhost:3000/rpc")
   .withProfile("preprod")
   .withParty("sender", await cip30Party(api))
-  .withParty("receiver", Party.address("addr_test1..."));
+  .withParty("receiver", Party.address("addr_test1..."))
+  .build();
 ```
 
 For multi-key wallets (where one wallet returns several vkey witnesses for a

--- a/sdk/src/facade/builder.ts
+++ b/sdk/src/facade/builder.ts
@@ -1,84 +1,85 @@
-import type { ArgMap } from '../core/index.js';
-import type { Protocol } from '../tii/protocol.js';
+import type { ArgMap, TirEnvelope } from '../core/index.js';
 import type { TrpClient } from '../trp/client.js';
-import { MissingParamsError, UnknownPartyError } from './errors.js';
-import type { Party } from './party.js';
-import { partyAddress } from './party.js';
+import type { ResolveParams } from '../trp/spec.js';
+import { type Party, partyAddress } from './party.js';
 import { ResolvedTx } from './resolved.js';
 
+/**
+ * Builder for transaction invocation.
+ *
+ * Holds the resolve inputs directly: the TIR envelope, the environment values
+ * from the selected profile (with builder-supplied overrides already folded
+ * in), the bound parties, and the typed args. Drives a single `resolve()` path
+ * regardless of whether the upstream was a runtime-loaded `Protocol` or
+ * codegen-embedded fragments.
+ */
 export class TxBuilder {
-  readonly #protocol: Protocol;
+  readonly #tir: TirEnvelope;
   readonly #trp: TrpClient;
-  readonly #txName: string;
-  readonly #args: ArgMap;
-  readonly #parties: Map<string, Party>;
-  readonly #profile: string | undefined;
+  #env: ArgMap = {};
+  readonly #parties: Map<string, Party> = new Map();
+  readonly #args: ArgMap = {};
 
-  constructor(
-    protocol: Protocol,
-    trp: TrpClient,
-    txName: string,
-    parties: Map<string, Party>,
-    profile: string | undefined,
-  ) {
-    this.#protocol = protocol;
+  constructor(trp: TrpClient, tir: TirEnvelope) {
     this.#trp = trp;
-    this.#txName = txName;
-    this.#args = {};
-    this.#parties = parties;
-    this.#profile = profile;
+    this.#tir = tir;
   }
 
-  arg(name: string, value: unknown): TxBuilder {
+  /** Sets the environment values applied to this transaction. */
+  env(env: ArgMap): this {
+    this.#env = { ...env };
+    return this;
+  }
+
+  /**
+   * Attaches party definitions (signers or read-only addresses). Names are
+   * matched case-insensitively; later entries override earlier ones.
+   */
+  parties(parties: Iterable<readonly [string, Party]>): this {
+    for (const [name, party] of parties) {
+      this.#parties.set(name.toLowerCase(), party);
+    }
+    return this;
+  }
+
+  /** Adds a single argument (case-insensitive name). */
+  arg(name: string, value: unknown): this {
     this.#args[name.toLowerCase()] = value;
     return this;
   }
 
-  args(map: Record<string, unknown>): TxBuilder {
-    for (const [key, value] of Object.entries(map)) {
-      this.#args[key.toLowerCase()] = value;
+  /** Adds multiple arguments (case-insensitive names). */
+  args(map: Record<string, unknown>): this {
+    for (const [k, v] of Object.entries(map)) {
+      this.#args[k.toLowerCase()] = v;
     }
     return this;
   }
 
+  /** Resolves the transaction through the TRP client. */
   async resolve(): Promise<ResolvedTx> {
-    const invocation = this.#protocol.invoke(
-      this.#txName,
-      this.#profile,
-    );
-
-    const knownParties = new Set(
-      Object.keys(this.#protocol.parties()).map((k) => k.toLowerCase()),
-    );
-
+    const merged: ArgMap = {};
+    for (const [k, v] of Object.entries(this.#env)) merged[k] = v;
     for (const [name, party] of this.#parties) {
-      if (!knownParties.has(name)) {
-        throw new UnknownPartyError(name);
-      }
-      invocation.setArg(name, partyAddress(party));
+      merged[name] = partyAddress(party);
     }
+    for (const [k, v] of Object.entries(this.#args)) merged[k] = v;
 
-    invocation.setArgs(this.#args);
+    const request: ResolveParams = {
+      tir: this.#tir,
+      args: merged,
+    };
 
-    const missing = [...invocation.unspecifiedParams()]
-      .map(([k]) => k)
-      .sort();
+    const envelope = await this.#trp.resolve(request);
 
-    if (missing.length > 0) {
-      throw new MissingParamsError(missing);
-    }
-
-    const resolveReq = invocation.intoResolveRequest();
-    const envelope = await this.#trp.resolve(resolveReq);
-
-    const signers: { name: string; address: string; signer: import('../signer/signer.js').Signer }[] = [];
+    const signers: {
+      name: string;
+      address: string;
+      signer: import('../signer/signer.js').Signer;
+    }[] = [];
     for (const [name, party] of this.#parties) {
       if (party.kind === 'signer') {
-        signers.push({
-          name,
-          address: party.address,
-          signer: party.signer,
-        });
+        signers.push({ name, address: party.address, signer: party.signer });
       }
     }
 

--- a/sdk/src/facade/client.test.ts
+++ b/sdk/src/facade/client.test.ts
@@ -2,20 +2,21 @@ import { jest } from '@jest/globals';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Protocol } from '../tii/protocol.js';
-import { TrpClient } from '../trp/client.js';
+import { UnknownProfileError, UnknownTxError } from '../tii/errors.js';
 import { Tx3Client } from './client.js';
+import { Tx3ClientBuilder } from './clientBuilder.js';
 import { Party } from './party.js';
 import { PollConfig } from './poll.js';
 import { Ed25519Signer } from '../signer/ed25519.js';
 import {
+  MissingTrpEndpointError,
   UnknownPartyError,
-  MissingParamsError,
   SubmitHashMismatchError,
   FinalizedFailedError,
   FinalizedTimeoutError,
 } from './errors.js';
 import type { TxWitness } from '../trp/spec.js';
-import type { Signer } from '../signer/signer.js';
+import type { Signer, SignRequest } from '../signer/signer.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURE = path.resolve(__dirname, '../../tests/fixtures/transfer.tii');
@@ -23,24 +24,7 @@ const SENDER_KEY = 'aa'.repeat(32);
 const SENDER_ADDR = 'addr_test1_sender';
 const RECEIVER_ADDR = 'addr_test1_receiver';
 const TX_HASH = 'bb'.repeat(32);
-const DEFAULT_MNEMONIC = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
-const INTEGRATION_ENV = {
-  endpoint: process.env.TRP_ENDPOINT_PREPROD ?? 'http://localhost:9999/rpc',
-  apiKey: process.env.TRP_API_KEY_PREPROD ?? '',
-  partyAAddress: process.env.TEST_PARTY_A_ADDRESS ?? SENDER_ADDR,
-  partyAMnemonic:
-    process.env.TEST_PARTY_A_MNEMONIC ?? process.env.TEST_PARTY_B_MNEMONIC ?? DEFAULT_MNEMONIC,
-  partyBAddress: process.env.TEST_PARTY_B_ADDRESS ?? RECEIVER_ADDR,
-  partyBMnemonic:
-    process.env.TEST_PARTY_B_MNEMONIC ?? process.env.TEST_PARTY_A_MNEMONIC ?? DEFAULT_MNEMONIC,
-};
-
-function makeTrpClient(): TrpClient {
-  const headers = INTEGRATION_ENV.apiKey
-    ? { 'dmtr-api-key': INTEGRATION_ENV.apiKey }
-    : undefined;
-  return new TrpClient({ endpoint: INTEGRATION_ENV.endpoint, headers });
-}
+const ENDPOINT = 'http://localhost:9999/rpc';
 
 function jsonRpcOk(result: unknown) {
   return { jsonrpc: '2.0', result, id: '1' };
@@ -62,6 +46,22 @@ function mockFetchSequence(...responses: unknown[]) {
 let originalFetch: typeof globalThis.fetch;
 let protocol: Protocol;
 
+function baseBuilder(): Tx3ClientBuilder {
+  return protocol
+    .client()
+    .trpEndpoint(ENDPOINT)
+    .withProfile('preprod');
+}
+
+function builtClient(): Tx3Client {
+  const signer = Ed25519Signer.fromHex(SENDER_ADDR, SENDER_KEY);
+  return baseBuilder()
+    .withParty('sender', Party.signer(signer))
+    .withParty('receiver', Party.address(RECEIVER_ADDR))
+    .withParty('middleman', Party.address(RECEIVER_ADDR))
+    .build();
+}
+
 beforeAll(async () => {
   protocol = await Protocol.fromFile(FIXTURE);
 });
@@ -74,7 +74,111 @@ afterEach(() => {
   globalThis.fetch = originalFetch;
 });
 
-describe('Facade unit behavior', () => {
+describe('Tx3ClientBuilder', () => {
+  test('Protocol.client() seeds a builder', () => {
+    expect(protocol.client()).toBeInstanceOf(Tx3ClientBuilder);
+  });
+
+  test('build() returns a Tx3Client', () => {
+    expect(builtClient()).toBeInstanceOf(Tx3Client);
+  });
+
+  test('build() throws MissingTrpEndpointError without an endpoint', () => {
+    expect(() => protocol.client().build()).toThrow(MissingTrpEndpointError);
+  });
+
+  test('build() throws MissingTrpEndpointError on empty endpoint', () => {
+    expect(() => protocol.client().trpEndpoint('').build()).toThrow(
+      MissingTrpEndpointError,
+    );
+  });
+
+  test('build() throws UnknownProfileError for an undeclared profile', () => {
+    expect(() =>
+      protocol.client().trpEndpoint(ENDPOINT).withProfile('not-a-profile').build(),
+    ).toThrow(UnknownProfileError);
+  });
+
+  test('build() throws UnknownPartyError for an undeclared party', () => {
+    expect(() =>
+      baseBuilder()
+        .withParty('stranger', Party.address('addr_stranger'))
+        .build(),
+    ).toThrow(UnknownPartyError);
+  });
+
+  test('withPartyUnchecked bypasses declared-party validation in build()', () => {
+    expect(() =>
+      baseBuilder()
+        .withPartyUnchecked('stranger', Party.address('addr_stranger'))
+        .build(),
+    ).not.toThrow();
+  });
+
+  test('withHeader merges into TRP options', () => {
+    const builder = protocol
+      .client()
+      .trpEndpoint(ENDPOINT)
+      .withHeader('dmtr-api-key', 'secret');
+    // Build should succeed (endpoint supplied).
+    expect(() => builder.build()).not.toThrow();
+  });
+
+  test('withEnvValue overrides profile env at resolve time', async () => {
+    const resolveResponse = jsonRpcOk({ hash: TX_HASH, tx: 'cafebabe' });
+    const fetchMock = mockFetchSequence(resolveResponse);
+    globalThis.fetch = fetchMock as never;
+
+    const client = baseBuilder()
+      .withPartyUnchecked('sender', Party.address(SENDER_ADDR))
+      .withPartyUnchecked('receiver', Party.address(RECEIVER_ADDR))
+      .withPartyUnchecked('middleman', Party.address(RECEIVER_ADDR))
+      .withEnvValue('network', 'overridden')
+      .build();
+
+    await client.tx('transfer').arg('quantity', 100).resolve();
+
+    const call = fetchMock.mock.calls[0] as [string, { body: string }];
+    const payload = JSON.parse(call[1].body) as {
+      params: { args: Record<string, unknown> };
+    };
+    expect(payload.params.args.network).toBe('overridden');
+  });
+
+  test('built client has no withProfile method', () => {
+    const client = builtClient() as unknown as Record<string, unknown>;
+    expect(client.withProfile).toBeUndefined();
+  });
+
+  test('built-client withParty validates against declared parties', () => {
+    expect(() =>
+      builtClient().withParty('stranger', Party.address('addr_stranger')),
+    ).toThrow(UnknownPartyError);
+  });
+
+  test('Tx3ClientBuilder.fromParts produces a usable client (codegen flow)', async () => {
+    const resolveResponse = jsonRpcOk({ hash: TX_HASH, tx: 'cafebabe' });
+    globalThis.fetch = mockFetchSequence(resolveResponse) as never;
+
+    const tirs = protocol.txs();
+    const transactions = new Map(
+      Object.entries(tirs).map(([k, v]) => [k, v.tir]),
+    );
+    const profiles = new Map();
+
+    const client = Tx3ClientBuilder.fromParts(transactions, profiles, [])
+      .trpEndpoint(ENDPOINT)
+      .withPartyUnchecked('sender', Party.address(SENDER_ADDR))
+      .withPartyUnchecked('receiver', Party.address(RECEIVER_ADDR))
+      .withPartyUnchecked('middleman', Party.address(RECEIVER_ADDR))
+      .build();
+
+    const resolved = await client.tx('transfer').arg('quantity', 100).resolve();
+    expect(resolved.hash).toBe(TX_HASH);
+  });
+});
+
+describe('Tx3Client lifecycle', () => {
   test('happy path: resolve → sign → submit → waitForConfirmed', async () => {
     const resolveResponse = jsonRpcOk({ hash: TX_HASH, tx: 'cafebabe' });
     const submitResponse = jsonRpcOk({ hash: TX_HASH });
@@ -96,16 +200,7 @@ describe('Facade unit behavior', () => {
       statusConfirmed,
     ) as never;
 
-    const trp = makeTrpClient();
-    const signer = Ed25519Signer.fromHex(INTEGRATION_ENV.partyAAddress, SENDER_KEY);
-
-    const tx3 = new Tx3Client(protocol, trp)
-      .withProfile('preprod')
-      .withParty('sender', Party.signer(signer))
-      .withParty('receiver', Party.address(INTEGRATION_ENV.partyBAddress))
-      .withParty('middleman', Party.address(INTEGRATION_ENV.partyBAddress));
-
-    const status = await tx3
+    const status = await builtClient()
       .tx('transfer')
       .arg('quantity', 10_000_000)
       .resolve()
@@ -117,49 +212,16 @@ describe('Facade unit behavior', () => {
     expect(status.confirmations).toBe(5);
   });
 
-  test('UnknownPartyError when party not in protocol', async () => {
-    const trp = makeTrpClient();
-
-    const tx3 = new Tx3Client(protocol, trp)
-      .withParty('stranger', Party.address('addr_test1_stranger'));
-
-    await expect(
-      tx3.tx('transfer').arg('quantity', 100).resolve(),
-    ).rejects.toThrow(UnknownPartyError);
-  });
-
-  test('MissingParamsError when arg is missing', async () => {
-    const resolveResponse = jsonRpcOk({ hash: TX_HASH, tx: 'cafebabe' });
-    globalThis.fetch = mockFetchSequence(resolveResponse) as never;
-
-    const trp = makeTrpClient();
-    const signer = Ed25519Signer.fromHex(INTEGRATION_ENV.partyAAddress, SENDER_KEY);
-
-    const tx3 = new Tx3Client(protocol, trp)
-      .withProfile('preprod')
-      .withParty('sender', Party.signer(signer))
-      .withParty('receiver', Party.address(INTEGRATION_ENV.partyBAddress))
-      .withParty('middleman', Party.address(INTEGRATION_ENV.partyBAddress));
-
-    await expect(tx3.tx('transfer').resolve()).rejects.toThrow(MissingParamsError);
+  test('tx() throws UnknownTxError for an undeclared transaction', () => {
+    expect(() => builtClient().tx('not-a-tx')).toThrow(UnknownTxError);
   });
 
   test('SubmitHashMismatchError when server returns different hash', async () => {
     const resolveResponse = jsonRpcOk({ hash: TX_HASH, tx: 'cafebabe' });
     const submitResponse = jsonRpcOk({ hash: 'different_hash' });
-
     globalThis.fetch = mockFetchSequence(resolveResponse, submitResponse) as never;
 
-    const trp = makeTrpClient();
-    const signer = Ed25519Signer.fromHex(INTEGRATION_ENV.partyAAddress, SENDER_KEY);
-
-    const tx3 = new Tx3Client(protocol, trp)
-      .withProfile('preprod')
-      .withParty('sender', Party.signer(signer))
-      .withParty('receiver', Party.address(INTEGRATION_ENV.partyBAddress))
-      .withParty('middleman', Party.address(INTEGRATION_ENV.partyBAddress));
-
-    const resolved = await tx3.tx('transfer').arg('quantity', 100).resolve();
+    const resolved = await builtClient().tx('transfer').arg('quantity', 100).resolve();
     const signed = await resolved.sign();
 
     await expect(signed.submit()).rejects.toThrow(SubmitHashMismatchError);
@@ -180,16 +242,7 @@ describe('Facade unit behavior', () => {
       statusDropped,
     ) as never;
 
-    const trp = makeTrpClient();
-    const signer = Ed25519Signer.fromHex(INTEGRATION_ENV.partyAAddress, SENDER_KEY);
-
-    const tx3 = new Tx3Client(protocol, trp)
-      .withProfile('preprod')
-      .withParty('sender', Party.signer(signer))
-      .withParty('receiver', Party.address(INTEGRATION_ENV.partyBAddress))
-      .withParty('middleman', Party.address(INTEGRATION_ENV.partyBAddress));
-
-    const submitted = await tx3
+    const submitted = await builtClient()
       .tx('transfer')
       .arg('quantity', 100)
       .resolve()
@@ -216,16 +269,7 @@ describe('Facade unit behavior', () => {
       statusPending,
     ) as never;
 
-    const trp = makeTrpClient();
-    const signer = Ed25519Signer.fromHex(INTEGRATION_ENV.partyAAddress, SENDER_KEY);
-
-    const tx3 = new Tx3Client(protocol, trp)
-      .withProfile('preprod')
-      .withParty('sender', Party.signer(signer))
-      .withParty('receiver', Party.address(INTEGRATION_ENV.partyBAddress))
-      .withParty('middleman', Party.address(INTEGRATION_ENV.partyBAddress));
-
-    const submitted = await tx3
+    const submitted = await builtClient()
       .tx('transfer')
       .arg('quantity', 100)
       .resolve()
@@ -254,7 +298,7 @@ describe('Facade unit behavior', () => {
 
     const customSigner: Signer = {
       address: () => 'addr_test1_custom',
-      sign: async (hash: string): Promise<TxWitness> => {
+      sign: async (_request: SignRequest): Promise<TxWitness> => {
         await Promise.resolve();
         return {
           key: { content: 'aabbccdd', contentType: 'hex' },
@@ -264,14 +308,13 @@ describe('Facade unit behavior', () => {
       },
     };
 
-    const trp = makeTrpClient();
-    const tx3 = new Tx3Client(protocol, trp)
-      .withProfile('preprod')
+    const client = baseBuilder()
       .withParty('sender', Party.signer(customSigner))
-      .withParty('receiver', Party.address(INTEGRATION_ENV.partyBAddress))
-      .withParty('middleman', Party.address(INTEGRATION_ENV.partyBAddress));
+      .withParty('receiver', Party.address(RECEIVER_ADDR))
+      .withParty('middleman', Party.address(RECEIVER_ADDR))
+      .build();
 
-    const status = await tx3
+    const status = await client
       .tx('transfer')
       .arg('quantity', 100)
       .resolve()
@@ -286,20 +329,14 @@ describe('Facade unit behavior', () => {
     const resolveResponse = jsonRpcOk({ hash: TX_HASH, tx: 'cafebabe' });
     globalThis.fetch = mockFetchSequence(resolveResponse) as never;
 
-    const trp = makeTrpClient();
-    const signer = Ed25519Signer.fromHex(INTEGRATION_ENV.partyAAddress, SENDER_KEY);
-
-    const tx3 = new Tx3Client(protocol, trp)
-      .withProfile('preprod')
+    const signer = Ed25519Signer.fromHex(SENDER_ADDR, SENDER_KEY);
+    const client = baseBuilder()
       .withParty('SeNdEr', Party.signer(signer))
-      .withParty('RECEIVER', Party.address(INTEGRATION_ENV.partyBAddress))
-      .withParty('Middleman', Party.address(INTEGRATION_ENV.partyBAddress));
+      .withParty('RECEIVER', Party.address(RECEIVER_ADDR))
+      .withParty('Middleman', Party.address(RECEIVER_ADDR))
+      .build();
 
-    const resolved = await tx3
-      .tx('transfer')
-      .arg('quantity', 100)
-      .resolve();
-
+    const resolved = await client.tx('transfer').arg('quantity', 100).resolve();
     expect(resolved.hash).toBe(TX_HASH);
   });
 
@@ -309,33 +346,20 @@ describe('Facade unit behavior', () => {
     expect(config.delayMs).toBe(5000);
   });
 
-  test('withProfile returns a new client', () => {
-    const trp = makeTrpClient();
-    const a = new Tx3Client(protocol, trp);
-    const b = a.withProfile('preprod');
-    expect(b).not.toBe(a);
-  });
-
-  test('withParties bulk attach', async () => {
+  test('withParties bulk attach on builder', async () => {
     const resolveResponse = jsonRpcOk({ hash: TX_HASH, tx: 'cafebabe' });
     globalThis.fetch = mockFetchSequence(resolveResponse) as never;
 
-    const trp = makeTrpClient();
-    const signer = Ed25519Signer.fromHex(INTEGRATION_ENV.partyAAddress, SENDER_KEY);
-
-    const tx3 = new Tx3Client(protocol, trp)
-      .withProfile('preprod')
+    const signer = Ed25519Signer.fromHex(SENDER_ADDR, SENDER_KEY);
+    const client = baseBuilder()
       .withParties({
         sender: Party.signer(signer),
-        receiver: Party.address(INTEGRATION_ENV.partyBAddress),
-        middleman: Party.address(INTEGRATION_ENV.partyBAddress),
-      });
+        receiver: Party.address(RECEIVER_ADDR),
+        middleman: Party.address(RECEIVER_ADDR),
+      })
+      .build();
 
-    const resolved = await tx3
-      .tx('transfer')
-      .arg('quantity', 100)
-      .resolve();
-
+    const resolved = await client.tx('transfer').arg('quantity', 100).resolve();
     expect(resolved.hash).toBe(TX_HASH);
   });
 });
@@ -344,6 +368,7 @@ describe('re-export canary', () => {
   test('top-level re-exports are defined', async () => {
     const mod = await import('../index.js');
     expect(mod.Tx3Client).toBeDefined();
+    expect(mod.Tx3ClientBuilder).toBeDefined();
     expect(mod.Party).toBeDefined();
     expect(mod.PollConfig).toBeDefined();
     expect(mod.CardanoSigner).toBeDefined();
@@ -351,6 +376,8 @@ describe('re-export canary', () => {
     expect(mod.Protocol).toBeDefined();
     expect(mod.TrpClient).toBeDefined();
     expect(mod.Tx3Error).toBeDefined();
+    expect(mod.MissingTrpEndpointError).toBeDefined();
+    expect(mod.BuilderError).toBeDefined();
     expect(mod.toJson).toBeDefined();
     expect(mod.fromJson).toBeDefined();
     expect(mod.trp).toBeDefined();

--- a/sdk/src/facade/client.ts
+++ b/sdk/src/facade/client.ts
@@ -1,62 +1,157 @@
-import type { Protocol } from '../tii/protocol.js';
+import type { ArgMap, TirEnvelope } from '../core/index.js';
+import { UnknownTxError } from '../tii/errors.js';
 import type { TrpClient } from '../trp/client.js';
 import { TxBuilder } from './builder.js';
-import type { Party } from './party.js';
+import { UnknownPartyError } from './errors.js';
+import { type Party, partyAddress } from './party.js';
+import type { Profile } from './profile.js';
 
+/**
+ * High-level client over a Tx3 protocol.
+ *
+ * Holds the deconstructed protocol parts — per-transaction TIR envelopes, the
+ * set of declared party names, the selected profile — plus the runtime state
+ * (TRP client, bound parties, env overrides). Built through `Tx3ClientBuilder`
+ * (obtained via `Protocol.client()` or `Tx3ClientBuilder.fromParts(...)`).
+ * Profile selection is locked in at build time: there is no profile-switching
+ * method on the built client.
+ */
 export class Tx3Client {
-  readonly #protocol: Protocol;
+  readonly #transactions: ReadonlyMap<string, TirEnvelope>;
+  readonly #knownParties: ReadonlySet<string>;
   readonly #trp: TrpClient;
-  readonly #parties: Map<string, Party>;
-  readonly #profile: string | undefined;
+  readonly #boundParties: Map<string, Party>;
+  readonly #selectedProfile: Profile | undefined;
+  readonly #envOverrides: ArgMap;
 
-  constructor(
-    protocol: Protocol,
+  private constructor(
+    transactions: ReadonlyMap<string, TirEnvelope>,
+    knownParties: ReadonlySet<string>,
     trp: TrpClient,
-    parties?: Map<string, Party>,
-    profile?: string,
+    boundParties: Map<string, Party>,
+    selectedProfile: Profile | undefined,
+    envOverrides: ArgMap,
   ) {
-    this.#protocol = protocol;
+    this.#transactions = transactions;
+    this.#knownParties = knownParties;
     this.#trp = trp;
-    this.#parties = parties ?? new Map();
-    this.#profile = profile;
+    this.#boundParties = boundParties;
+    this.#selectedProfile = selectedProfile;
+    this.#envOverrides = envOverrides;
   }
 
-  withProfile(name: string): Tx3Client {
-    return new Tx3Client(
-      this.#protocol,
-      this.#trp,
-      new Map(this.#parties),
-      name,
-    );
-  }
-
-  withParty(name: string, party: Party): Tx3Client {
-    const parties = new Map(this.#parties);
-    parties.set(name.toLowerCase(), party);
-    return new Tx3Client(this.#protocol, this.#trp, parties, this.#profile);
-  }
-
-  withParties(
-    entries: Record<string, Party> | Iterable<[string, Party]>,
+  /** @internal — call site is `Tx3ClientBuilder.build()`. */
+  static _fromBuilder(
+    transactions: Map<string, TirEnvelope>,
+    knownParties: Set<string>,
+    trp: TrpClient,
+    boundParties: Map<string, Party>,
+    selectedProfile: Profile | undefined,
+    envOverrides: ArgMap,
   ): Tx3Client {
-    const parties = new Map(this.#parties);
-    const iterable =
-      Symbol.iterator in entries
-        ? (entries as Iterable<[string, Party]>)
-        : Object.entries(entries as Record<string, Party>);
-    for (const [name, party] of iterable) {
-      parties.set(name.toLowerCase(), party);
-    }
-    return new Tx3Client(this.#protocol, this.#trp, parties, this.#profile);
+    return new Tx3Client(
+      transactions,
+      knownParties,
+      trp,
+      boundParties,
+      selectedProfile,
+      envOverrides,
+    );
   }
 
+  /**
+   * Late-binding party setter. Returns a new client with the party bound (the
+   * caller is the source of truth for replacement semantics — later wins).
+   *
+   * @throws {UnknownPartyError} if `name` is not a party declared by the
+   *   protocol.
+   */
+  withParty(name: string, party: Party): Tx3Client {
+    const lower = name.toLowerCase();
+    if (!this.#knownParties.has(lower)) {
+      throw new UnknownPartyError(lower);
+    }
+    const next = new Map(this.#boundParties);
+    next.set(lower, party);
+    return this.#withParties(next);
+  }
+
+  /**
+   * Late-binding party setter that skips the declared-party lookup. Intended
+   * for codegen-generated wrappers; hand-written code SHOULD prefer
+   * `withParty`.
+   */
+  withPartyUnchecked(name: string, party: Party): Tx3Client {
+    const next = new Map(this.#boundParties);
+    next.set(name.toLowerCase(), party);
+    return this.#withParties(next);
+  }
+
+  /** Late-binds multiple parties at once. See `withParty`. */
+  withParties(
+    entries: Record<string, Party> | Iterable<readonly [string, Party]>,
+  ): Tx3Client {
+    const next = new Map(this.#boundParties);
+    const iter =
+      Symbol.iterator in entries
+        ? (entries as Iterable<readonly [string, Party]>)
+        : Object.entries(entries as Record<string, Party>);
+    for (const [name, party] of iter) {
+      const lower = name.toLowerCase();
+      if (!this.#knownParties.has(lower)) throw new UnknownPartyError(lower);
+      next.set(lower, party);
+    }
+    return this.#withParties(next);
+  }
+
+  /**
+   * Starts building a transaction invocation.
+   *
+   * @throws {UnknownTxError} if `name` is not a transaction declared by the
+   *   protocol.
+   */
   tx(name: string): TxBuilder {
-    return new TxBuilder(
-      this.#protocol,
+    const tir = this.#transactions.get(name);
+    if (!tir) throw new UnknownTxError(name);
+
+    const env = this.#mergedEnv();
+    const parties = this.#mergedParties();
+    return new TxBuilder(this.#trp, tir).env(env).parties(parties);
+  }
+
+  #withParties(next: Map<string, Party>): Tx3Client {
+    return new Tx3Client(
+      this.#transactions,
+      this.#knownParties,
       this.#trp,
-      name,
-      new Map(this.#parties),
-      this.#profile,
+      next,
+      this.#selectedProfile,
+      this.#envOverrides,
     );
+  }
+
+  #mergedEnv(): ArgMap {
+    const env: ArgMap = { ...(this.#selectedProfile?.environment ?? {}) };
+    for (const [k, v] of Object.entries(this.#envOverrides)) env[k] = v;
+    return env;
+  }
+
+  #mergedParties(): Map<string, Party> {
+    const merged = new Map<string, Party>();
+    if (this.#selectedProfile) {
+      for (const [name, address] of Object.entries(
+        this.#selectedProfile.parties,
+      )) {
+        merged.set(name.toLowerCase(), {
+          kind: 'address',
+          address,
+        });
+      }
+    }
+    for (const [name, party] of this.#boundParties) merged.set(name, party);
+    return merged;
   }
 }
+
+/** Re-exported for the `clientBuilder.ts` resolver chain. */
+export { partyAddress };

--- a/sdk/src/facade/clientBuilder.ts
+++ b/sdk/src/facade/clientBuilder.ts
@@ -1,0 +1,223 @@
+import type { ArgMap, TirEnvelope } from '../core/index.js';
+import type { Protocol } from '../tii/protocol.js';
+import { UnknownProfileError } from '../tii/errors.js';
+import { TrpClient, type ClientOptions } from '../trp/client.js';
+import { Tx3Client } from './client.js';
+import {
+  MissingTrpEndpointError,
+  UnknownPartyError,
+} from './errors.js';
+import type { Party } from './party.js';
+import type { Profile } from './profile.js';
+
+/**
+ * Builder for `Tx3Client`.
+ *
+ * Obtained via `Protocol.client()` for the dynamic flow, or
+ * `Tx3ClientBuilder.fromParts(...)` for the codegen flow. All fallible
+ * validation — TRP endpoint present, selected profile declared, every bound
+ * party declared — happens in `build()`. Optional setters never throw, so
+ * chains stay fluent.
+ *
+ * @example
+ * ```ts
+ * const protocol = await Protocol.fromFile('protocol.tii');
+ * const client = protocol
+ *   .client()
+ *   .trpEndpoint('https://trp.example')
+ *   .withProfile('preprod')
+ *   .withParty('sender', Party.signer(signer))
+ *   .build();
+ * ```
+ */
+export class Tx3ClientBuilder {
+  readonly #transactions: Map<string, TirEnvelope>;
+  readonly #profiles: Map<string, Profile>;
+  readonly #knownParties: Set<string>;
+
+  #trpOptions: ClientOptions | undefined;
+  #profile: string | undefined;
+  readonly #parties: Map<string, Party> = new Map();
+  readonly #uncheckedParties: Map<string, Party> = new Map();
+  readonly #envOverrides: ArgMap = {};
+
+  private constructor(
+    transactions: Map<string, TirEnvelope>,
+    profiles: Map<string, Profile>,
+    knownParties: Set<string>,
+  ) {
+    this.#transactions = transactions;
+    this.#profiles = profiles;
+    this.#knownParties = knownParties;
+  }
+
+  /**
+   * Seeds a builder with already-deconstructed protocol fragments. Codegen-
+   * generated bindings call this with embedded per-transaction TIR envelopes,
+   * per-profile environment + party-address maps, and (typically) an empty
+   * known-parties set — the typed `withPartyUnchecked` setters bake party
+   * names into the wrapper methods so runtime name validation is unnecessary.
+   */
+  static fromParts(
+    transactions: Record<string, TirEnvelope> | Map<string, TirEnvelope>,
+    profiles: Record<string, Profile> | Map<string, Profile>,
+    knownParties: Iterable<string>,
+  ): Tx3ClientBuilder {
+    const txMap =
+      transactions instanceof Map
+        ? new Map(transactions)
+        : new Map(Object.entries(transactions));
+    const profileMap =
+      profiles instanceof Map
+        ? new Map(profiles)
+        : new Map(Object.entries(profiles));
+    const partySet = new Set<string>();
+    for (const name of knownParties) partySet.add(name.toLowerCase());
+    return new Tx3ClientBuilder(txMap, profileMap, partySet);
+  }
+
+  /** @internal entry point used by `Protocol.client()`. */
+  static fromProtocol(protocol: Protocol): Tx3ClientBuilder {
+    const txs = protocol.txs();
+    const transactions = new Map<string, TirEnvelope>();
+    for (const [name, tx] of Object.entries(txs)) {
+      transactions.set(name, tx.tir);
+    }
+
+    const profiles = new Map<string, Profile>();
+    const declaredProfiles = protocol.profiles();
+    for (const [name, profile] of Object.entries(declaredProfiles)) {
+      const environment =
+        profile.environment &&
+        typeof profile.environment === 'object' &&
+        !Array.isArray(profile.environment)
+          ? { ...(profile.environment as ArgMap) }
+          : {};
+      profiles.set(name, {
+        environment,
+        parties: profile.parties ? { ...profile.parties } : {},
+      });
+    }
+
+    const knownParties = new Set<string>();
+    for (const partyName of Object.keys(protocol.parties())) {
+      knownParties.add(partyName.toLowerCase());
+    }
+
+    return new Tx3ClientBuilder(transactions, profiles, knownParties);
+  }
+
+  /** Sets the full TRP client options. */
+  trp(options: ClientOptions): this {
+    this.#trpOptions = { ...options };
+    return this;
+  }
+
+  /** Shorthand for `trp({ endpoint })`. */
+  trpEndpoint(url: string): this {
+    this.#trpOptions = { endpoint: url };
+    return this;
+  }
+
+  /**
+   * Adds a single TRP request header. Initializes the TRP options to an empty
+   * endpoint if not yet set — callers must still supply the endpoint via
+   * `trp()` or `trpEndpoint()`.
+   */
+  withHeader(key: string, value: string): this {
+    const opts = this.#trpOptions ?? { endpoint: '' };
+    const headers = { ...(opts.headers ?? {}) };
+    headers[key] = value;
+    this.#trpOptions = { ...opts, headers };
+    return this;
+  }
+
+  /** Selects a profile by name. Validated in `build()`. */
+  withProfile(name: string): this {
+    this.#profile = name;
+    return this;
+  }
+
+  /**
+   * Binds a party (signer or read-only address) by name. The name is validated
+   * against the protocol's declared parties in `build()`.
+   */
+  withParty(name: string, party: Party): this {
+    this.#parties.set(name.toLowerCase(), party);
+    return this;
+  }
+
+  /**
+   * Binds a party without validating the name against the protocol's declared
+   * parties. Intended for codegen-generated wrappers — the name is baked into
+   * the typed setter at codegen time, so runtime validation would always pass.
+   * Hand-written code SHOULD prefer `withParty`.
+   */
+  withPartyUnchecked(name: string, party: Party): this {
+    this.#uncheckedParties.set(name.toLowerCase(), party);
+    return this;
+  }
+
+  /** Binds multiple parties at once. See `withParty`. */
+  withParties(
+    entries: Record<string, Party> | Iterable<readonly [string, Party]>,
+  ): this {
+    const iter =
+      Symbol.iterator in entries
+        ? (entries as Iterable<readonly [string, Party]>)
+        : Object.entries(entries as Record<string, Party>);
+    for (const [name, party] of iter) this.withParty(name, party);
+    return this;
+  }
+
+  /**
+   * Sets a single environment value. Merged on top of the selected profile's
+   * environment at resolve time (override wins).
+   */
+  withEnvValue(key: string, value: unknown): this {
+    this.#envOverrides[key] = value;
+    return this;
+  }
+
+  /**
+   * Validates the builder state and materializes the `Tx3Client`.
+   *
+   * @throws {MissingTrpEndpointError} if no TRP endpoint was supplied.
+   * @throws {UnknownProfileError} if the selected profile is not declared.
+   * @throws {UnknownPartyError} if any bound party is not declared.
+   */
+  build(): Tx3Client {
+    if (!this.#trpOptions || this.#trpOptions.endpoint.length === 0) {
+      throw new MissingTrpEndpointError();
+    }
+
+    let selectedProfile: Profile | undefined;
+    if (this.#profile !== undefined) {
+      const found = this.#profiles.get(this.#profile);
+      if (!found) throw new UnknownProfileError(this.#profile);
+      selectedProfile = found;
+    }
+
+    for (const name of this.#parties.keys()) {
+      if (!this.#knownParties.has(name)) {
+        throw new UnknownPartyError(name);
+      }
+    }
+
+    const trp = new TrpClient(this.#trpOptions);
+
+    const boundParties = new Map<string, Party>();
+    for (const [name, party] of this.#parties) boundParties.set(name, party);
+    for (const [name, party] of this.#uncheckedParties)
+      boundParties.set(name, party);
+
+    return Tx3Client._fromBuilder(
+      this.#transactions,
+      this.#knownParties,
+      trp,
+      boundParties,
+      selectedProfile,
+      { ...this.#envOverrides },
+    );
+  }
+}

--- a/sdk/src/facade/errors.ts
+++ b/sdk/src/facade/errors.ts
@@ -1,9 +1,21 @@
 import { Tx3Error } from '../core/errors.js';
 import type { TxStage } from '../trp/spec.js';
 
-export abstract class ResolutionError extends Tx3Error {}
+/**
+ * Errors raised by `Tx3ClientBuilder.build()` and by late-binding setters on
+ * the built `Tx3Client`. Discriminate the group via `instanceof BuilderError`,
+ * or pick a specific variant (`MissingTrpEndpointError`, `UnknownPartyError`).
+ * `UnknownProfileError` and `UnknownTxError` are re-used from `tii/errors`.
+ */
+export abstract class BuilderError extends Tx3Error {}
 
-export class UnknownPartyError extends ResolutionError {
+export class MissingTrpEndpointError extends BuilderError {
+  constructor() {
+    super('TRP endpoint not configured');
+  }
+}
+
+export class UnknownPartyError extends BuilderError {
   readonly party: string;
 
   constructor(party: string) {
@@ -11,6 +23,8 @@ export class UnknownPartyError extends ResolutionError {
     this.party = party;
   }
 }
+
+export abstract class ResolutionError extends Tx3Error {}
 
 export class MissingParamsError extends ResolutionError {
   readonly params: string[];

--- a/sdk/src/facade/index.ts
+++ b/sdk/src/facade/index.ts
@@ -1,13 +1,17 @@
 export { Tx3Client } from './client.js';
+export { Tx3ClientBuilder } from './clientBuilder.js';
 export { TxBuilder } from './builder.js';
 export { Party, partyAddress } from './party.js';
+export type { Profile } from './profile.js';
 export { PollConfig } from './poll.js';
 export { ResolvedTx } from './resolved.js';
 export { SignedTx, type WitnessInfo } from './signed.js';
 export { SubmittedTx } from './submitted.js';
 export {
-  ResolutionError,
+  BuilderError,
+  MissingTrpEndpointError,
   UnknownPartyError,
+  ResolutionError,
   MissingParamsError,
   SubmissionError,
   SubmitHashMismatchError,

--- a/sdk/src/facade/profile.ts
+++ b/sdk/src/facade/profile.ts
@@ -1,0 +1,14 @@
+import type { ArgMap } from '../core/index.js';
+
+/**
+ * A named profile baked into a client: environment values and party
+ * addresses keyed by name.
+ *
+ * Produced either by deconstructing a loaded `Protocol` inside
+ * `Tx3ClientBuilder.fromProtocol`, or by feeding the per-profile JSON blob a
+ * generated codegen client embeds through `Tx3ClientBuilder.fromParts`.
+ */
+export interface Profile {
+  environment: ArgMap;
+  parties: Record<string, string>;
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,6 +1,8 @@
 // Facade (§3.3–§3.7)
 export { Tx3Client } from './facade/client.js';
+export { Tx3ClientBuilder } from './facade/clientBuilder.js';
 export { Party } from './facade/party.js';
+export type { Profile } from './facade/profile.js';
 export { PollConfig } from './facade/poll.js';
 export { TxBuilder } from './facade/builder.js';
 export { ResolvedTx } from './facade/resolved.js';
@@ -50,8 +52,10 @@ export {
 } from './tii/errors.js';
 export { SignerError } from './signer/errors.js';
 export {
-  ResolutionError,
+  BuilderError,
+  MissingTrpEndpointError,
   UnknownPartyError,
+  ResolutionError,
   MissingParamsError,
   SubmissionError,
   SubmitHashMismatchError,

--- a/sdk/src/tii/protocol.ts
+++ b/sdk/src/tii/protocol.ts
@@ -1,6 +1,13 @@
+import { Tx3ClientBuilder } from '../facade/clientBuilder.js';
 import { Invocation } from './invocation.js';
 import { ParamType, paramsFromSchema, type ParamMap } from './paramType.js';
-import type { PartySpec, TiiFile, Transaction } from './spec.js';
+import type {
+  JsonSchema,
+  PartySpec,
+  Profile,
+  TiiFile,
+  Transaction,
+} from './spec.js';
 import {
   InvalidJsonError,
   UnknownProfileError,
@@ -47,6 +54,22 @@ export class Protocol {
 
   parties(): Record<string, PartySpec> {
     return this.spec.parties ?? {};
+  }
+
+  profiles(): Record<string, Profile> {
+    return this.spec.profiles ?? {};
+  }
+
+  environment(): JsonSchema | undefined {
+    return this.spec.environment;
+  }
+
+  /**
+   * Returns a fresh `Tx3ClientBuilder` seeded with this protocol's transactions,
+   * profiles, and declared parties. Entry point for the dynamic flow.
+   */
+  client(): Tx3ClientBuilder {
+    return Tx3ClientBuilder.fromProtocol(this);
   }
 
   private ensureTx(name: string): Transaction {

--- a/sdk/tests/e2e/happy-path.test.ts
+++ b/sdk/tests/e2e/happy-path.test.ts
@@ -3,9 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { CardanoSigner } from '../../src/signer/cardano.js';
 import { Party } from '../../src/facade/party.js';
 import { PollConfig } from '../../src/facade/poll.js';
-import { Tx3Client } from '../../src/facade/client.js';
 import { Protocol } from '../../src/tii/protocol.js';
-import { TrpClient } from '../../src/trp/client.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURE = path.resolve(__dirname, '../fixtures/transfer.tii');
@@ -22,16 +20,22 @@ describe('Facade e2e', () => {
   e2eTest('resolve -> sign -> submit -> waitForConfirmed', async () => {
     const protocol = await Protocol.fromFile(FIXTURE);
     const signer = await CardanoSigner.fromMnemonic(partyAAddress as string, partyAMnemonic as string);
-    const headers = apiKey ? { 'dmtr-api-key': apiKey } : undefined;
-
-    const trp = new TrpClient({ endpoint: endpoint as string, headers });
     const receiver = partyBAddress ?? partyAAddress;
 
-    const tx3 = new Tx3Client(protocol, trp)
-      .withProfile('preprod')
+    let builder = protocol
+      .client()
+      .trpEndpoint(endpoint as string)
+      .withProfile('preprod');
+
+    if (apiKey) {
+      builder = builder.withHeader('dmtr-api-key', apiKey);
+    }
+
+    const tx3 = builder
       .withParty('sender', Party.signer(signer))
       .withParty('receiver', Party.address(receiver as string))
-      .withParty('middleman', Party.address(receiver as string));
+      .withParty('middleman', Party.address(receiver as string))
+      .build();
 
     const status = await tx3
       .tx('transfer')


### PR DESCRIPTION
## Summary

Ports the unified-builder pattern from `rust-sdk` (already on `codegen-v1beta0-4-g761a685`) into web-sdk so the §3.3/§3.6 facade rows of [`sdks/parity-matrix.md`](https://github.com/tx3-lang/toolchain/blob/main/sdks/parity-matrix.md) flip ❌→✅.

- New `Tx3ClientBuilder` (with `Protocol.client()` + `fromParts(...)` seeders, `trp` / `trpEndpoint` / `withHeader` / `withProfile` / `withParty` / `withParties` / `withPartyUnchecked` / `withEnvValue` setters, single `build()` terminal).
- `Tx3Client` now owns the deconstructed protocol parts; `withProfile` is **builder-only** (removed from the built client per §3.6); `tx(name)` throws `UnknownTxError` at call site.
- `TxBuilder` is **source-agnostic** — both dynamic and codegen flows drive the same `resolve()` path.
- New `BuilderError` family + `MissingTrpEndpointError`; `UnknownPartyError` re-parented from `ResolutionError` → `BuilderError` (still `Tx3Error`-rooted, still `instanceof`-discriminable).
- Codegen template (`.trix/client-lib/protocol.ts.hbs`) now wraps `Tx3ClientBuilder.fromParts(...)`; per-party setters route through `withPartyUnchecked`; profiles emitted as individual `SdkProfile` consts with a typed `Profile` string-union.
- Top-level re-exports add `Tx3ClientBuilder`, `Profile`, `BuilderError`, `MissingTrpEndpointError`.

Spec references: [`sdks/sdk-spec/api-surface/facade.md`](https://github.com/tx3-lang/toolchain/blob/main/sdks/sdk-spec/api-surface/facade.md) §3.3, §3.4, §3.6; [`sdks/sdk-spec/codegen/generated-surface.md`](https://github.com/tx3-lang/toolchain/blob/main/sdks/sdk-spec/codegen/generated-surface.md) §C.3a–d.

## Breaking changes

- `new Tx3Client(protocol, trp)` is gone — construct via `protocol.client()...build()` instead.
- `Tx3Client.withProfile(name)` removed — call `withProfile` on the builder (switching profiles now requires a new client).
- `tx(name)` throws `UnknownTxError` synchronously instead of deferring to `resolve()`.
- `UnknownPartyError`'s parent class changed (`ResolutionError` → `BuilderError`); both still extend `Tx3Error`.
- Client-side `MissingParamsError` pre-flight removed (TRP server still emits `MissingTxArgError`).

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run test:unit` — **120/120 pass** (12 new builder-pattern tests)
- [x] `tx3c codegen` against `sdk/tests/fixtures/transfer.tii` renders all expected symbols (`Tx3ClientBuilder`, `fromParts`, `TransferParams`, `TRANSFER_TIR`, per-party `withSender`/`withReceiver`/`withMiddleman`)
- [ ] **`codegen-check.sh` will fail in CI** until this lands on npm — the script installs `tx3-sdk@latest`, which is still v0.11.0 without `Tx3ClientBuilder`. Expected for a template flip (same situation when rust-sdk landed this pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)