### PR TITLE
chore(release): bump tx3-sdk to 0.12.0

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tx3-sdk",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Software Development Kit for the Tx3 Language",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary

Bumps `tx3-sdk` to **0.12.0** to align with the fleet's 0.12 release train. The unified-builder port that merged in [#29](https://github.com/tx3-lang/web-sdk/pull/29) is a breaking change and per [release-policy.md](https://github.com/tx3-lang/toolchain/blob/main/sdks/sdk-spec/release-policy.md) any MINOR/MAJOR change MUST be coordinated across all SDKs (rust-sdk's workspace already declares 0.12.0).

After this lands, a `v0.12.0` tag will be pushed to trigger the release workflow → publish to npm.

## Test plan

- [x] One-line version bump, no code change. CI covers everything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)