### PR TITLE
feat(tii)!: interpret the full complex param-type model

### DIFF
--- a/sdk/src/tii/errors.ts
+++ b/sdk/src/tii/errors.ts
@@ -23,15 +23,3 @@ export class UnknownProfileError extends TiiError {
     this.profile = profile;
   }
 }
-
-export class InvalidParamsSchemaError extends TiiError {
-  constructor(message = 'invalid params schema') {
-    super(message);
-  }
-}
-
-export class InvalidParamTypeError extends TiiError {
-  constructor(message = 'invalid param type') {
-    super(message);
-  }
-}

--- a/sdk/src/tii/paramType.test.ts
+++ b/sdk/src/tii/paramType.test.ts
@@ -1,60 +1,145 @@
 import { ParamType, paramsFromSchema } from './paramType.js';
-import { InvalidParamTypeError } from './errors.js';
 import type { JsonSchema } from './spec.js';
 
+const TII = 'https://tx3.land/specs/v1beta0/tii#/$defs/';
+const CORE = 'https://tx3.land/specs/v1beta0/core#';
+
 describe('ParamType.fromJsonSchema', () => {
-  it('maps builtin refs in the tii#/$defs form', () => {
-    const bytes: JsonSchema = { $ref: 'https://tx3.land/specs/v1beta0/tii#/$defs/Bytes' };
-    const addr: JsonSchema = { $ref: 'https://tx3.land/specs/v1beta0/tii#/$defs/Address' };
-    const utxo: JsonSchema = { $ref: 'https://tx3.land/specs/v1beta0/tii#/$defs/UtxoRef' };
-
-    expect(ParamType.fromJsonSchema(bytes).kind).toBe('bytes');
-    expect(ParamType.fromJsonSchema(addr).kind).toBe('address');
-    expect(ParamType.fromJsonSchema(utxo).kind).toBe('utxoRef');
+  it('maps primitives and unit', () => {
+    expect(ParamType.fromJsonSchema({ type: 'integer' }).kind).toBe('integer');
+    expect(ParamType.fromJsonSchema({ type: 'boolean' }).kind).toBe('boolean');
+    expect(ParamType.fromJsonSchema({ type: 'null' }).kind).toBe('unit');
   });
 
-  it('still maps the legacy core# ref form', () => {
-    const bytes: JsonSchema = { $ref: 'https://tx3.land/specs/v1beta0/core#Bytes' };
-    expect(ParamType.fromJsonSchema(bytes).kind).toBe('bytes');
+  it.each([TII, CORE])('maps every core $ref by trailing name (%s)', (prefix) => {
+    const cases: Array<[string, ParamType['kind']]> = [
+      ['Bytes', 'bytes'],
+      ['Address', 'address'],
+      ['UtxoRef', 'utxoRef'],
+      ['Utxo', 'utxo'],
+      ['AnyAsset', 'anyAsset'],
+    ];
+    for (const [name, kind] of cases) {
+      expect(ParamType.fromJsonSchema({ $ref: prefix + name }).kind).toBe(kind);
+    }
   });
 
-  it('resolves a component ref to its schema as a custom param', () => {
+  it('maps an array with `items` to a nested list', () => {
+    const list: JsonSchema = {
+      type: 'array',
+      items: { type: 'array', items: { type: 'boolean' } },
+    };
+    expect(ParamType.fromJsonSchema(list)).toEqual({
+      kind: 'list',
+      inner: { kind: 'list', inner: { kind: 'boolean' } },
+    });
+  });
+
+  it('maps an array with `prefixItems` (and `items: false`) to a tuple', () => {
+    const tuple: JsonSchema = {
+      type: 'array',
+      prefixItems: [{ type: 'integer' }, { $ref: `${TII}Bytes` }],
+      items: false,
+    };
+    expect(ParamType.fromJsonSchema(tuple)).toEqual({
+      kind: 'tuple',
+      elements: [{ kind: 'integer' }, { kind: 'bytes' }],
+    });
+  });
+
+  it('maps an object with `additionalProperties` to a map', () => {
+    const map: JsonSchema = {
+      type: 'object',
+      additionalProperties: { type: 'integer' },
+    };
+    expect(ParamType.fromJsonSchema(map)).toEqual({
+      kind: 'map',
+      value: { kind: 'integer' },
+    });
+  });
+
+  it('maps an object with `properties` to a record', () => {
     const record: JsonSchema = {
       type: 'object',
-      properties: { policy_id: { type: 'string' } },
+      properties: { price: { type: 'integer' }, live: { type: 'boolean' } },
+      required: ['price', 'live'],
+    };
+    expect(ParamType.fromJsonSchema(record)).toEqual({
+      kind: 'record',
+      fields: { price: { kind: 'integer' }, live: { kind: 'boolean' } },
+    });
+  });
+
+  it('maps a oneOf to an externally-tagged variant', () => {
+    const variant: JsonSchema = {
+      oneOf: [
+        {
+          type: 'object',
+          additionalProperties: false,
+          required: ['Buy'],
+          properties: { Buy: { type: 'object', properties: {}, required: [] } },
+        },
+        {
+          type: 'object',
+          additionalProperties: false,
+          required: ['Sell'],
+          properties: {
+            Sell: {
+              type: 'object',
+              properties: { price: { type: 'integer' } },
+              required: ['price'],
+            },
+          },
+        },
+      ],
+    };
+    const param = ParamType.fromJsonSchema(variant);
+    expect(param.kind).toBe('variant');
+    if (param.kind !== 'variant') throw new Error('unreachable');
+    expect(param.cases.map((c) => c.tag)).toEqual(['Buy', 'Sell']);
+    expect(param.cases[1].fields).toEqual({
+      kind: 'record',
+      fields: { price: { kind: 'integer' } },
+    });
+  });
+
+  it('resolves a component ref into components.schemas and recurses', () => {
+    const components = {
+      AssetClass: {
+        type: 'object',
+        properties: { policy: { $ref: `${TII}Bytes` } },
+        required: ['policy'],
+      } as JsonSchema,
     };
     const ref: JsonSchema = { $ref: '#/components/schemas/AssetClass' };
-
-    const param = ParamType.fromJsonSchema(ref, { AssetClass: record });
-    expect(param.kind).toBe('custom');
-    expect(param).toEqual({ kind: 'custom', schema: record });
+    expect(ParamType.fromJsonSchema(ref, components)).toEqual({
+      kind: 'record',
+      fields: { policy: { kind: 'bytes' } },
+    });
   });
 
-  it('falls back to the ref schema when components are absent', () => {
-    const ref: JsonSchema = { $ref: '#/components/schemas/AssetClass' };
-    const param = ParamType.fromJsonSchema(ref);
-    expect(param).toEqual({ kind: 'custom', schema: ref });
-  });
-
-  it('maps an inline object (record) to a custom param', () => {
-    const record: JsonSchema = { type: 'object', properties: { x: { type: 'integer' } } };
-    expect(ParamType.fromJsonSchema(record)).toEqual({ kind: 'custom', schema: record });
-  });
-
-  it('maps a oneOf (variant) to a custom param', () => {
-    const variant: JsonSchema = { oneOf: [{ type: 'object' }] };
-    expect(ParamType.fromJsonSchema(variant)).toEqual({ kind: 'custom', schema: variant });
-  });
-
-  it('throws on an unknown builtin ref', () => {
-    const ref: JsonSchema = { $ref: 'https://tx3.land/specs/v1beta0/tii#/$defs/Nope' };
-    expect(() => ParamType.fromJsonSchema(ref)).toThrow(InvalidParamTypeError);
+  it('falls back to unknown rather than throwing', () => {
+    // unresolved component ref
+    expect(ParamType.fromJsonSchema({ $ref: '#/components/schemas/Nope' }).kind).toBe('unknown');
+    // unknown builtin ref
+    expect(ParamType.fromJsonSchema({ $ref: `${TII}Nope` }).kind).toBe('unknown');
+    // bare string is genuinely untyped — must NOT become address
+    expect(ParamType.fromJsonSchema({ type: 'string' }).kind).toBe('unknown');
+    // array with neither items nor prefixItems
+    expect(ParamType.fromJsonSchema({ type: 'array' }).kind).toBe('unknown');
+    // empty / object without properties
+    expect(ParamType.fromJsonSchema({}).kind).toBe('unknown');
   });
 });
 
 describe('paramsFromSchema', () => {
   it('threads components through to each property', () => {
-    const components = { AssetClass: { type: 'object' } as JsonSchema };
+    const components = {
+      AssetClass: {
+        type: 'object',
+        properties: { policy: { $ref: `${TII}Bytes` } },
+      } as JsonSchema,
+    };
     const params: JsonSchema = {
       type: 'object',
       properties: {
@@ -64,7 +149,10 @@ describe('paramsFromSchema', () => {
     };
 
     const map = paramsFromSchema(params, components);
-    expect(map.get('asset')).toEqual({ kind: 'custom', schema: components.AssetClass });
+    expect(map.get('asset')).toEqual({
+      kind: 'record',
+      fields: { policy: { kind: 'bytes' } },
+    });
     expect(map.get('quantity')?.kind).toBe('integer');
   });
 });

--- a/sdk/src/tii/paramType.ts
+++ b/sdk/src/tii/paramType.ts
@@ -1,71 +1,174 @@
-import { InvalidParamTypeError } from './errors.js';
 import type { JsonSchema } from './spec.js';
+
+/** One case of a {@link ParamType} of kind `variant`. */
+export interface VariantCase {
+  tag: string;
+  fields: ParamType;
+}
 
 export type ParamType =
   | { kind: 'bytes' }
   | { kind: 'integer' }
   | { kind: 'boolean' }
+  | { kind: 'unit' }
   | { kind: 'utxoRef' }
   | { kind: 'address' }
+  | { kind: 'utxo' }
+  | { kind: 'anyAsset' }
   | { kind: 'list'; inner: ParamType }
-  | { kind: 'custom'; schema: JsonSchema };
+  | { kind: 'tuple'; elements: ParamType[] }
+  | { kind: 'map'; value: ParamType }
+  | { kind: 'record'; fields: Record<string, ParamType> }
+  | { kind: 'variant'; cases: VariantCase[] }
+  | { kind: 'unknown'; schema: JsonSchema };
+
+function isSchema(value: unknown): value is JsonSchema {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+/** Matches a built-in core type by the trailing name of its `$ref`, so both the
+ * canonical `…/tii#/$defs/<Name>` and legacy `…/core#<Name>` forms resolve. */
+function coreRefType(ref: string): ParamType | undefined {
+  const name = ref.split('#').pop()?.split('/').pop();
+  switch (name) {
+    case 'Bytes':
+      return ParamType.bytes();
+    case 'Address':
+      return ParamType.address();
+    case 'UtxoRef':
+      return ParamType.utxoRef();
+    case 'Utxo':
+      return ParamType.utxo();
+    case 'AnyAsset':
+      return ParamType.anyAsset();
+    default:
+      return undefined;
+  }
+}
+
+/** Interprets one externally-tagged `oneOf` branch into a {@link VariantCase}. */
+function variantCase(
+  branch: unknown,
+  components?: Record<string, JsonSchema>,
+): VariantCase {
+  const schema = isSchema(branch) ? branch : {};
+  const required = schema['required'];
+  const tag =
+    Array.isArray(required) && typeof required[0] === 'string' ? required[0] : '';
+
+  let fields: ParamType = ParamType.unknown(schema);
+  const properties = schema['properties'];
+  if (isSchema(properties)) {
+    const fieldSchema = (properties as Record<string, unknown>)[tag];
+    if (isSchema(fieldSchema)) {
+      fields = ParamType.fromJsonSchema(fieldSchema, components);
+    }
+  }
+  return { tag, fields };
+}
 
 export const ParamType = {
   bytes: (): ParamType => ({ kind: 'bytes' }),
   integer: (): ParamType => ({ kind: 'integer' }),
   boolean: (): ParamType => ({ kind: 'boolean' }),
+  unit: (): ParamType => ({ kind: 'unit' }),
   utxoRef: (): ParamType => ({ kind: 'utxoRef' }),
   address: (): ParamType => ({ kind: 'address' }),
+  utxo: (): ParamType => ({ kind: 'utxo' }),
+  anyAsset: (): ParamType => ({ kind: 'anyAsset' }),
   list: (inner: ParamType): ParamType => ({ kind: 'list', inner }),
-  custom: (schema: JsonSchema): ParamType => ({ kind: 'custom', schema }),
+  tuple: (elements: ParamType[]): ParamType => ({ kind: 'tuple', elements }),
+  map: (value: ParamType): ParamType => ({ kind: 'map', value }),
+  record: (fields: Record<string, ParamType>): ParamType => ({
+    kind: 'record',
+    fields,
+  }),
+  variant: (cases: VariantCase[]): ParamType => ({ kind: 'variant', cases }),
+  unknown: (schema: JsonSchema): ParamType => ({ kind: 'unknown', schema }),
 
+  /**
+   * Interprets a JSON schema node into a {@link ParamType}. Never throws: any
+   * shape it does not recognize — a bare `string`, an unresolved object, an
+   * unknown `$ref` — becomes a `unknown` kind carrying the raw schema.
+   * `components` is the TII's `components.schemas` table, used to resolve
+   * `#/components/schemas/<Name>` references to user-defined types.
+   */
   fromJsonSchema(
     schema: JsonSchema,
     components?: Record<string, JsonSchema>,
   ): ParamType {
+    if (!isSchema(schema)) {
+      return ParamType.unknown(schema);
+    }
+
     const ref = schema['$ref'];
     if (typeof ref === 'string') {
       // User-defined record / variant, referenced into components.schemas.
       if (ref.includes('/components/schemas/')) {
         const name = ref.split('/').pop() as string;
-        return ParamType.custom(components?.[name] ?? schema);
+        const resolved = components?.[name];
+        return resolved
+          ? ParamType.fromJsonSchema(resolved, components)
+          : ParamType.unknown(schema);
       }
-      // Builtin core type, matched by trailing name so both the
-      // `…/tii#/$defs/<Name>` and legacy `…/core#<Name>` forms resolve.
-      const name = ref.split('#').pop()?.split('/').pop();
-      switch (name) {
-        case 'Bytes':
-          return ParamType.bytes();
-        case 'Address':
-          return ParamType.address();
-        case 'UtxoRef':
-          return ParamType.utxoRef();
-        default:
-          throw new InvalidParamTypeError(`unknown $ref: ${ref}`);
-      }
+      return coreRefType(ref) ?? ParamType.unknown(schema);
     }
 
-    // Variant: a tagged union of cases.
+    // Variant: a tagged union of externally-tagged cases.
     if (Array.isArray(schema['oneOf'])) {
-      return ParamType.custom(schema);
+      return ParamType.variant(
+        (schema['oneOf'] as unknown[]).map((branch) =>
+          variantCase(branch, components),
+        ),
+      );
     }
 
     const type = schema['type'];
-    if (typeof type === 'string') {
-      switch (type) {
-        case 'integer':
-          return ParamType.integer();
-        case 'boolean':
-          return ParamType.boolean();
-        // Inline record / custom object shape.
-        case 'object':
-          return ParamType.custom(schema);
-        default:
-          throw new InvalidParamTypeError(`unsupported type: ${type}`);
+    switch (type) {
+      case 'integer':
+        return ParamType.integer();
+      case 'boolean':
+        return ParamType.boolean();
+      case 'null':
+        return ParamType.unit();
+      // Compound array shape: a tuple carries positional `prefixItems`, a list
+      // carries a single `items` element schema.
+      case 'array': {
+        const prefixItems = schema['prefixItems'];
+        if (Array.isArray(prefixItems)) {
+          return ParamType.tuple(
+            prefixItems.map((el) => ParamType.fromJsonSchema(el as JsonSchema, components)),
+          );
+        }
+        const items = schema['items'];
+        if (isSchema(items)) {
+          return ParamType.list(ParamType.fromJsonSchema(items, components));
+        }
+        return ParamType.unknown(schema);
       }
+      // Object shape: `additionalProperties` is a map; `properties` is a record.
+      case 'object': {
+        const additional = schema['additionalProperties'];
+        if (isSchema(additional)) {
+          return ParamType.map(ParamType.fromJsonSchema(additional, components));
+        }
+        const properties = schema['properties'];
+        if (isSchema(properties)) {
+          const fields: Record<string, ParamType> = {};
+          for (const [key, value] of Object.entries(
+            properties as Record<string, unknown>,
+          )) {
+            fields[key] = isSchema(value)
+              ? ParamType.fromJsonSchema(value, components)
+              : ParamType.unknown(schema);
+          }
+          return ParamType.record(fields);
+        }
+        return ParamType.unknown(schema);
+      }
+      default:
+        return ParamType.unknown(schema);
     }
-
-    throw new InvalidParamTypeError();
   },
 };
 
@@ -77,12 +180,14 @@ export function paramsFromSchema(
 ): ParamMap {
   const params: ParamMap = new Map();
   const properties = schema['properties'];
-  if (properties && typeof properties === 'object' && !Array.isArray(properties)) {
+  if (isSchema(properties)) {
     for (const [key, value] of Object.entries(properties as Record<string, unknown>)) {
-      if (!value || typeof value !== 'object' || Array.isArray(value)) {
-        throw new InvalidParamTypeError(`property ${key} is not a schema object`);
-      }
-      params.set(key, ParamType.fromJsonSchema(value as JsonSchema, components));
+      params.set(
+        key,
+        isSchema(value)
+          ? ParamType.fromJsonSchema(value, components)
+          : ParamType.unknown(schema),
+      );
     }
   }
   return params;

--- a/sdk/src/tii/paramType.ts
+++ b/sdk/src/tii/paramType.ts
@@ -67,6 +67,69 @@ function variantCase(
   return { tag, fields };
 }
 
+/** Interprets a `$ref` node: a `#/components/schemas/<Name>` reference resolves
+ * against `components` (recursing), a core `$ref` maps by trailing name, anything
+ * else falls back to `unknown`. */
+function refType(
+  schema: JsonSchema,
+  ref: string,
+  components?: Record<string, JsonSchema>,
+): ParamType {
+  // User-defined record / variant, referenced into components.schemas.
+  if (ref.includes('/components/schemas/')) {
+    const name = ref.split('/').pop() as string;
+    const resolved = components?.[name];
+    return resolved
+      ? ParamType.fromJsonSchema(resolved, components)
+      : ParamType.unknown(schema);
+  }
+  return coreRefType(ref) ?? ParamType.unknown(schema);
+}
+
+/** Interprets an `array` schema: `prefixItems` → tuple, `items` → list, neither
+ * → `unknown`. */
+function arrayType(
+  schema: JsonSchema,
+  components?: Record<string, JsonSchema>,
+): ParamType {
+  const prefixItems = schema['prefixItems'];
+  if (Array.isArray(prefixItems)) {
+    return ParamType.tuple(
+      prefixItems.map((el) => ParamType.fromJsonSchema(el as JsonSchema, components)),
+    );
+  }
+  const items = schema['items'];
+  if (isSchema(items)) {
+    return ParamType.list(ParamType.fromJsonSchema(items, components));
+  }
+  return ParamType.unknown(schema);
+}
+
+/** Interprets an `object` schema: `additionalProperties` → map, `properties` →
+ * record, neither → `unknown`. */
+function objectType(
+  schema: JsonSchema,
+  components?: Record<string, JsonSchema>,
+): ParamType {
+  const additional = schema['additionalProperties'];
+  if (isSchema(additional)) {
+    return ParamType.map(ParamType.fromJsonSchema(additional, components));
+  }
+  const properties = schema['properties'];
+  if (isSchema(properties)) {
+    const fields: Record<string, ParamType> = {};
+    for (const [key, value] of Object.entries(
+      properties as Record<string, unknown>,
+    )) {
+      fields[key] = isSchema(value)
+        ? ParamType.fromJsonSchema(value, components)
+        : ParamType.unknown(schema);
+    }
+    return ParamType.record(fields);
+  }
+  return ParamType.unknown(schema);
+}
+
 export const ParamType = {
   bytes: (): ParamType => ({ kind: 'bytes' }),
   integer: (): ParamType => ({ kind: 'integer' }),
@@ -103,15 +166,7 @@ export const ParamType = {
 
     const ref = schema['$ref'];
     if (typeof ref === 'string') {
-      // User-defined record / variant, referenced into components.schemas.
-      if (ref.includes('/components/schemas/')) {
-        const name = ref.split('/').pop() as string;
-        const resolved = components?.[name];
-        return resolved
-          ? ParamType.fromJsonSchema(resolved, components)
-          : ParamType.unknown(schema);
-      }
-      return coreRefType(ref) ?? ParamType.unknown(schema);
+      return refType(schema, ref, components);
     }
 
     // Variant: a tagged union of externally-tagged cases.
@@ -123,49 +178,17 @@ export const ParamType = {
       );
     }
 
-    const type = schema['type'];
-    switch (type) {
+    switch (schema['type']) {
       case 'integer':
         return ParamType.integer();
       case 'boolean':
         return ParamType.boolean();
       case 'null':
         return ParamType.unit();
-      // Compound array shape: a tuple carries positional `prefixItems`, a list
-      // carries a single `items` element schema.
-      case 'array': {
-        const prefixItems = schema['prefixItems'];
-        if (Array.isArray(prefixItems)) {
-          return ParamType.tuple(
-            prefixItems.map((el) => ParamType.fromJsonSchema(el as JsonSchema, components)),
-          );
-        }
-        const items = schema['items'];
-        if (isSchema(items)) {
-          return ParamType.list(ParamType.fromJsonSchema(items, components));
-        }
-        return ParamType.unknown(schema);
-      }
-      // Object shape: `additionalProperties` is a map; `properties` is a record.
-      case 'object': {
-        const additional = schema['additionalProperties'];
-        if (isSchema(additional)) {
-          return ParamType.map(ParamType.fromJsonSchema(additional, components));
-        }
-        const properties = schema['properties'];
-        if (isSchema(properties)) {
-          const fields: Record<string, ParamType> = {};
-          for (const [key, value] of Object.entries(
-            properties as Record<string, unknown>,
-          )) {
-            fields[key] = isSchema(value)
-              ? ParamType.fromJsonSchema(value, components)
-              : ParamType.unknown(schema);
-          }
-          return ParamType.record(fields);
-        }
-        return ParamType.unknown(schema);
-      }
+      case 'array':
+        return arrayType(schema, components);
+      case 'object':
+        return objectType(schema, components);
       default:
         return ParamType.unknown(schema);
     }

--- a/sdk/src/tii/protocol.test.ts
+++ b/sdk/src/tii/protocol.test.ts
@@ -8,6 +8,7 @@ import {
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURE = path.resolve(__dirname, '../../tests/fixtures/transfer.tii');
+const COMPLEX_FIXTURE = path.resolve(__dirname, '../../tests/fixtures/complex.tii');
 
 describe('Protocol', () => {
   let protocol: Protocol;
@@ -69,6 +70,46 @@ describe('Protocol', () => {
 
     test('invoke with unknown profile throws UnknownProfileError', () => {
       expect(() => protocol.invoke('transfer', 'nonexistent')).toThrow(UnknownProfileError);
+    });
+
+    // Locks in the invoke path the paramType unit tests can't reach: threading
+    // spec.components.schemas into paramsFromSchema, and exposing party (Address)
+    // and environment-schema params. Asserts a real complex.tii produces the
+    // expected compound kinds, incl. a component-$ref Record and Variant.
+    test('invoke interprets complex params, parties, and environment', async () => {
+      const complex = await Protocol.fromFile(COMPLEX_FIXTURE);
+      const params = complex.invoke('complex').params();
+
+      const wantKind: Record<string, string> = {
+        quantity: 'integer',
+        flag: 'boolean',
+        nothing: 'unit',
+        recipient: 'address',
+        source: 'utxoRef',
+        bag: 'anyAsset',
+        amounts: 'list',
+        pair: 'tuple',
+        labels: 'map',
+        asset: 'record',
+        side: 'variant',
+        // Parties surface as implicit Address params (lowercased).
+        sender: 'address',
+        receiver: 'address',
+        // Protocol-level environment schema params.
+        fee: 'integer',
+      };
+      for (const [name, kind] of Object.entries(wantKind)) {
+        expect(params.get(name)?.kind).toBe(kind);
+      }
+
+      // The component-$ref Record must have resolved its inner Bytes field — this
+      // is the assertion that actually guards the components threading.
+      const asset = params.get('asset');
+      expect(asset?.kind === 'record' && asset.fields['policy']?.kind).toBe('bytes');
+
+      // The component-$ref Variant must have resolved its cases.
+      const side = params.get('side');
+      expect(side?.kind === 'variant' && side.cases.length).toBe(2);
     });
   });
 

--- a/sdk/tests/fixtures/complex.tii
+++ b/sdk/tests/fixtures/complex.tii
@@ -1,0 +1,119 @@
+{
+  "tii": {
+    "version": "v1beta0"
+  },
+  "protocol": {
+    "name": "complex-types",
+    "scope": "unknown",
+    "version": "0.0.1",
+    "description": "Schema-only fixture exercising every ParamType kind. The TIR envelope is a non-resolvable placeholder; this vector is for parameter-type interpretation tests, not TRP resolution."
+  },
+  "environment": {
+    "type": "object",
+    "properties": {
+      "fee": {
+        "type": "integer"
+      }
+    },
+    "required": ["fee"]
+  },
+  "parties": {
+    "sender": {},
+    "receiver": {}
+  },
+  "profiles": {
+    "local": {
+      "environment": {},
+      "parties": {}
+    }
+  },
+  "components": {
+    "schemas": {
+      "AssetClass": {
+        "type": "object",
+        "properties": {
+          "policy": { "$ref": "https://tx3.land/specs/v1beta0/tii#/$defs/Bytes" },
+          "name": { "$ref": "https://tx3.land/specs/v1beta0/tii#/$defs/Bytes" }
+        },
+        "required": ["policy", "name"]
+      },
+      "Side": {
+        "oneOf": [
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["Buy"],
+            "properties": {
+              "Buy": { "type": "object", "properties": {}, "required": [] }
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["Sell"],
+            "properties": {
+              "Sell": {
+                "type": "object",
+                "properties": { "price": { "type": "integer" } },
+                "required": ["price"]
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "transactions": {
+    "complex": {
+      "params": {
+        "type": "object",
+        "properties": {
+          "quantity": { "type": "integer" },
+          "flag": { "type": "boolean" },
+          "nothing": { "type": "null" },
+          "recipient": { "$ref": "https://tx3.land/specs/v1beta0/tii#/$defs/Address" },
+          "source": { "$ref": "https://tx3.land/specs/v1beta0/tii#/$defs/UtxoRef" },
+          "bag": { "$ref": "https://tx3.land/specs/v1beta0/tii#/$defs/AnyAsset" },
+          "amounts": {
+            "type": "array",
+            "items": { "type": "integer" }
+          },
+          "pair": {
+            "type": "array",
+            "prefixItems": [
+              { "type": "integer" },
+              { "$ref": "https://tx3.land/specs/v1beta0/tii#/$defs/Bytes" }
+            ],
+            "items": false,
+            "minItems": 2,
+            "maxItems": 2
+          },
+          "labels": {
+            "type": "object",
+            "additionalProperties": { "type": "integer" }
+          },
+          "asset": { "$ref": "#/components/schemas/AssetClass" },
+          "side": { "$ref": "#/components/schemas/Side" }
+        },
+        "required": [
+          "quantity",
+          "flag",
+          "nothing",
+          "recipient",
+          "source",
+          "bag",
+          "amounts",
+          "pair",
+          "labels",
+          "asset",
+          "side"
+        ]
+      },
+      "tir": {
+        "content": "00",
+        "encoding": "hex",
+        "version": "v1beta0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Extends `ParamType` to interpret every shape `tx3c` emits into the TII params schema, per the canonical model in the SDK spec's `api-surface/args.md`. The web-sdk slice of a cross-fleet complex-type parity effort (rust/go/python/web). Builds on the earlier list/tuple + trailing-name `$ref` work.

## Changes

- Adds **`unit` / `utxo` / `anyAsset` / `map`(value) / `record`(fields) / `variant`(cases)** kinds. The previous `object`→custom and `oneOf`→custom now resolve to structured `record` / `variant`, and `additionalProperties` to `map`.
- Resolves **`#/components/schemas/<Name>`** refs into the components table and recurses (previously wrapped opaquely without recursing).
- **Never throws** — unrecognized shapes (bare `string`, unresolved object, unknown `$ref`, array without items/prefixItems) become `unknown` carrying the raw schema.

## Tests

`npm test` — 131 pass (rewritten `paramType.test.ts` over the full canonical table incl. both ref forms, nested compounds, map/record/variant, component resolution, and never-throw fallbacks). `tsc --noEmit` clean.

Cross-checked against the shared fixture `sdk-spec/test-vectors/complex-types/complex.tii`.

## Breaking change

The `custom` kind is renamed to `unknown`, and `fromJsonSchema` / `paramsFromSchema` no longer throw `InvalidParamTypeError` (they return `unknown`). Needs a version bump per `sdk-spec/release-policy.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)