### PR TITLE
chore: release 0.13.0

### DIFF
--- a/.trix/client-lib/package.json.hbs
+++ b/.trix/client-lib/package.json.hbs
@@ -12,7 +12,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "tx3-sdk": "^0.7.0"
+    "tx3-sdk": "^0.13.0"
   },
   "devDependencies": {
     "@types/node": "^22.14.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10198,7 +10198,7 @@
     "packages/tx3-trp": {},
     "sdk": {
       "name": "tx3-sdk",
-      "version": "0.11.0",
+      "version": "0.13.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.4.0",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tx3-sdk",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Software Development Kit for the Tx3 Language",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Release-prep for the coordinated **0.13.0** SDK fleet train.

All four SDKs carry the unreleased breaking `feat(tii)!: interpret the full complex param-type model` change on top of the already-tagged `v0.12.0`. Per `sdk-spec/versioning.md` + `release-policy.md`, a breaking TII change forces at minimum a coordinated minor bump across the fleet, and `0.12.0` can't be reused — so the train moves to `0.13.0`.

This PR bumps the package version and the `.trix/client-lib` codegen template's pinned SDK requirement **in the same commit** (required by `sdk-spec/codegen/versioning.md` — the template requirement must not get ahead of the source version).

Merging this is the prerequisite for tagging the release (`release.yml` validates `tag == manifest version`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)